### PR TITLE
optimize the memory using of trilinear function; add early stop for training

### DIFF
--- a/config.py
+++ b/config.py
@@ -108,6 +108,7 @@ flags.DEFINE_float("l2_norm", 3e-7, "L2 norm scale")
 flags.DEFINE_integer("hidden", 96, "Hidden size")
 flags.DEFINE_integer("num_heads", 1, "Number of heads in self attention")
 flags.DEFINE_boolean("q2c", True, "Whether to use query to context attention or not")
+flags.DEFINE_integer("early_stop", 3, "Checkpoints for early stop")
 
 # Extensions (Uncomment corresponding code in download.sh to download the required data)
 glove_char_file = os.path.join(home, "data", "glove", "glove.840B.300d-char.txt")

--- a/layers.py
+++ b/layers.py
@@ -375,6 +375,175 @@ def get_timing_signal_1d(length, channels, min_timescale=1.0, max_timescale=1.0e
     signal = tf.reshape(signal, [1, length, channels])
     return signal
 
+def ndim(x):
+    """Copied from keras==2.0.6
+    Returns the number of axes in a tensor, as an integer.
+
+    # Arguments
+        x: Tensor or variable.
+
+    # Returns
+        Integer (scalar), number of axes.
+
+    # Examples
+    ```python
+        >>> from keras import backend as K
+        >>> inputs = K.placeholder(shape=(2, 4, 5))
+        >>> val = np.array([[1, 2], [3, 4]])
+        >>> kvar = K.variable(value=val)
+        >>> K.ndim(inputs)
+        3
+        >>> K.ndim(kvar)
+        2
+    ```
+    """
+    dims = x.get_shape()._dims
+    if dims is not None:
+        return len(dims)
+    return None
+
+def dot(x, y):
+    """Modified from keras==2.0.6
+    Multiplies 2 tensors (and/or variables) and returns a *tensor*.
+
+    When attempting to multiply a nD tensor
+    with a nD tensor, it reproduces the Theano behavior.
+    (e.g. `(2, 3) * (4, 3, 5) -> (2, 4, 5)`)
+
+    # Arguments
+        x: Tensor or variable.
+        y: Tensor or variable.
+
+    # Returns
+        A tensor, dot product of `x` and `y`.
+    """
+    if ndim(x) is not None and (ndim(x) > 2 or ndim(y) > 2):
+        x_shape = []
+        for i, s in zip(x.get_shape().as_list(), tf.unstack(tf.shape(x))):
+            if i is not None:
+                x_shape.append(i)
+            else:
+                x_shape.append(s)
+        x_shape = tuple(x_shape)
+        y_shape = []
+        for i, s in zip(y.get_shape().as_list(), tf.unstack(tf.shape(y))):
+            if i is not None:
+                y_shape.append(i)
+            else:
+                y_shape.append(s)
+        y_shape = tuple(y_shape)
+        y_permute_dim = list(range(ndim(y)))
+        y_permute_dim = [y_permute_dim.pop(-2)] + y_permute_dim
+        xt = tf.reshape(x, [-1, x_shape[-1]])
+        yt = tf.reshape(tf.transpose(y, perm=y_permute_dim), [y_shape[-2], -1])
+        return tf.reshape(tf.matmul(xt, yt),
+                          x_shape[:-1] + y_shape[:-2] + y_shape[-1:])
+    if isinstance(x, tf.SparseTensor):
+        out = tf.sparse_tensor_dense_matmul(x, y)
+    else:
+        out = tf.matmul(x, y)
+    return out
+
+def batch_dot(x, y, axes=None):
+    """Copy from keras==2.0.6
+    Batchwise dot product.
+
+    `batch_dot` is used to compute dot product of `x` and `y` when
+    `x` and `y` are data in batch, i.e. in a shape of
+    `(batch_size, :)`.
+    `batch_dot` results in a tensor or variable with less dimensions
+    than the input. If the number of dimensions is reduced to 1,
+    we use `expand_dims` to make sure that ndim is at least 2.
+
+    # Arguments
+        x: Keras tensor or variable with `ndim >= 2`.
+        y: Keras tensor or variable with `ndim >= 2`.
+        axes: list of (or single) int with target dimensions.
+            The lengths of `axes[0]` and `axes[1]` should be the same.
+
+    # Returns
+        A tensor with shape equal to the concatenation of `x`'s shape
+        (less the dimension that was summed over) and `y`'s shape
+        (less the batch dimension and the dimension that was summed over).
+        If the final rank is 1, we reshape it to `(batch_size, 1)`.
+    """
+    if isinstance(axes, int):
+        axes = (axes, axes)
+    x_ndim = ndim(x)
+    y_ndim = ndim(y)
+    if x_ndim > y_ndim:
+        diff = x_ndim - y_ndim
+        y = tf.reshape(y, tf.concat([tf.shape(y), [1] * (diff)], axis=0))
+    elif y_ndim > x_ndim:
+        diff = y_ndim - x_ndim
+        x = tf.reshape(x, tf.concat([tf.shape(x), [1] * (diff)], axis=0))
+    else:
+        diff = 0
+    if ndim(x) == 2 and ndim(y) == 2:
+        if axes[0] == axes[1]:
+            out = tf.reduce_sum(tf.multiply(x, y), axes[0])
+        else:
+            out = tf.reduce_sum(tf.multiply(tf.transpose(x, [1, 0]), y), axes[1])
+    else:
+        if axes is not None:
+            adj_x = None if axes[0] == ndim(x) - 1 else True
+            adj_y = True if axes[1] == ndim(y) - 1 else None
+        else:
+            adj_x = None
+            adj_y = None
+        out = tf.matmul(x, y, adjoint_a=adj_x, adjoint_b=adj_y)
+    if diff:
+        if x_ndim > y_ndim:
+            idx = x_ndim + y_ndim - 3
+        else:
+            idx = x_ndim - 1
+        out = tf.squeeze(out, list(range(idx, idx + diff)))
+    if ndim(out) == 1:
+        out = tf.expand_dims(out, 1)
+    return out
+
+def optimized_trilinear_for_attention(args, c_maxlen, q_maxlen, input_keep_prob=1.0,
+    scope='efficient_trilinear',
+    bias_initializer=tf.zeros_initializer(),
+    kernel_initializer=initializer()):
+    assert len(args) == 2, "just use for computing attention with two input"
+    arg0_shape = args[0].get_shape().as_list()
+    arg1_shape = args[1].get_shape().as_list()
+    if len(arg0_shape) != 3 or len(arg1_shape) != 3:
+        raise ValueError("`args` must be 3 dims (batch_size, len, dimension)")
+    if arg0_shape[2] != arg1_shape[2]:
+        raise ValueError("the last dimension of `args` must equal")
+    arg_size = arg0_shape[2]
+    dtype = args[0].dtype
+    droped_args = [tf.nn.dropout(arg, input_keep_prob) for arg in args]
+    with tf.variable_scope(scope):
+        weights4arg0 = tf.get_variable(
+            "linear_kernel4arg0", [arg_size, 1],
+            dtype=dtype,
+            regularizer=regularizer,
+            initializer=kernel_initializer)
+        weights4arg1 = tf.get_variable(
+            "linear_kernel4arg1", [arg_size, 1],
+            dtype=dtype,
+            regularizer=regularizer,
+            initializer=kernel_initializer)
+        weights4mlu = tf.get_variable(
+            "linear_kernel4mul", [1, 1, arg_size],
+            dtype=dtype,
+            regularizer=regularizer,
+            initializer=kernel_initializer)
+        biases = tf.get_variable(
+            "linear_bias", [1],
+            dtype=dtype,
+            regularizer=regularizer,
+            initializer=bias_initializer)
+        subres0 = tf.tile(dot(droped_args[0], weights4arg0), [1, 1, q_maxlen])
+        subres1 = tf.tile(tf.transpose(dot(droped_args[1], weights4arg1), perm=(0, 2, 1)), [1, c_maxlen, 1])
+        subres2 = batch_dot(droped_args[0] * weights4mlu, tf.transpose(droped_args[1], perm=(0, 2, 1)))
+        res = subres0 + subres1 + subres2
+        nn_ops.bias_add(res, biases)
+        return res
+
 def trilinear(args,
             output_size = 1,
             bias = True,

--- a/main.py
+++ b/main.py
@@ -47,6 +47,8 @@ def train(config):
 
         loss_save = 100.0
         patience = 0
+        best_f1 = 0.
+        best_em = 0.
 
         with tf.Session(config=sess_config) as sess:
             writer = tf.summary.FileWriter(config.log_dir)
@@ -75,7 +77,17 @@ def train(config):
                     metrics, summ = evaluate_batch(
                         model, dev_total // config.batch_size + 1, dev_eval_file, sess, "dev", handle, dev_handle)
 
-                    dev_loss = metrics["loss"]
+                    dev_f1 = metrics["f1"]
+                    dev_em = metrics["exact_match"]
+                    if dev_f1 < best_f1 and dev_em < best_em:
+                        patience += 1
+                        if patience > config.early_stop:
+                            break
+                    else:
+                        patience = 0
+                        best_em = max(best_em, dev_em)
+                        best_f1 = max(best_f1, dev_f1)
+
                     for s in summ:
                         writer.add_summary(s, global_step)
                     writer.flush()

--- a/model.py
+++ b/model.py
@@ -1,5 +1,5 @@
 import tensorflow as tf
-from layers import initializer, regularizer, residual_block, highway, conv, mask_logits, trilinear, total_params
+from layers import initializer, regularizer, residual_block, highway, conv, mask_logits, trilinear, total_params, optimized_trilinear_for_attention
 
 class Model(object):
     def __init__(self, config, batch, word_mat=None, char_mat=None, trainable=True, opt=True, demo = False, graph = None):
@@ -127,6 +127,7 @@ class Model(object):
             C = tf.tile(tf.expand_dims(c,2),[1,1,self.q_maxlen,1])
             Q = tf.tile(tf.expand_dims(q,1),[1,self.c_maxlen,1,1])
             S = trilinear([C, Q, C*Q], input_keep_prob = 1.0 - self.dropout)
+            S = optimized_trilinear_for_attention([c, q], self.c_maxlen, self.q_maxlen, input_keep_prob = 1.0 - self.dropout)
             mask_q = tf.expand_dims(self.q_mask, 1)
             S_ = tf.nn.softmax(mask_logits(S, mask = mask_q))
             mask_c = tf.expand_dims(self.c_mask, 2)


### PR DESCRIPTION
- Reduce the memory cost of trilinear from "N * BatchSize * C_len * Q_len * HiddenSize" to "N * BatchSize * C_len * Q_len", N is an integer. Which is about N * 0.23G -> N * 0.002G for HiddenSize 96, and about N * 0.31G -> N * 0.002G for HiddenSize 128.

The main idea behind the optimization is that:
The attention function of "[C, Q, C * Q] dot W" can be split to "C dot W1 + Q dot W2 + (C * Q) dot W3".
Given that, we could perform the dot function before the expand_dims and tile, so that the last dimension can be reduced from HiddenSize to 1 (as the last dimension of W is 1).
Btw, I think the current inputs of trilinear function obtain many memories, even the multi-head self-attention will cost more memories.

- Add early stop as current pipeline just save the last five models, it's very easy to overfitting so that we can't get the actually EM and F1 of dev set (the log is reported by the max length as 400, which is lower than the actual numbers).